### PR TITLE
Add England Squash feed

### DIFF
--- a/singular.jsonld
+++ b/singular.jsonld
@@ -33,6 +33,7 @@
     "https://www.sportsuite.co.uk/odapikey/datasite/",
     "https://www.participant.co.uk/participant/openactive/",
     "https://goteamup.com/api/openactive/v1/",
-    "https://openactive.played.co/openactive"
+    "https://openactive.played.co/openactive",
+    "https://squash.madeatsilverchip.com/public/v1/sessions"
   ]
 }


### PR DESCRIPTION
England Squash dataset site and fieed

## Publishing Checklist

I confirm the following:

- [x] My open data feeds conform to one of the permissable combinations specified in https://developer.openactive.io/publishing-data/data-feeds/types-of-feed
- [x] My open data feeds all pass the OpenActive Validator's model validation (https://validator.openactive.io/)
- [x] My open data feeds all pass the OpenActive Validator's RPDE feed validation (https://validator.openactive.io/rpde)
- [x] My open data feeds include activity list references as specified in https://developer.openactive.io/publishing-data/activity-list-references
- [x] My dataset site(s) each reference a GitHub Issues Board

## Maintenance Checklist

Our organisation is committed to:

- [x] Resolving issues that are raised on the GitHub Issues Board(s)
- [x] Ensuring activity providers are aware of the OpenActive opportunity on an ongoing basis
