### PR TITLE
Add England Squash dataset site

### DIFF
--- a/singular.jsonld
+++ b/singular.jsonld
@@ -17,6 +17,7 @@
     "http://data.britishorienteering.org.uk/",
     "http://data.britishtriathlon.org/",
     "https://data.englandnetball.co.uk/",
+    "https://www.englandsquash.com/openactive",
     "http://data.gomammoth.co.uk/",
     "https://data.goodgym.org/",
     "https://lawntennisassociation.github.io/",


### PR DESCRIPTION
Previous attempt to add England Squash erroneously gave their feed URL rather than their dataset site.

## Publishing Checklist

I confirm the following:

- [x] My open data feeds conform to one of the permissable combinations specified in https://developer.openactive.io/publishing-data/data-feeds/types-of-feed
- [x] My open data feeds all pass the OpenActive Validator's model validation (https://validator.openactive.io/)
- [x] My open data feeds all pass the OpenActive Validator's RPDE feed validation (https://validator.openactive.io/rpde)
- [x] My open data feeds include activity list references as specified in https://developer.openactive.io/publishing-data/activity-list-references
- [x] My dataset site(s) each reference a GitHub Issues Board

## Maintenance Checklist

Our organisation is committed to:

- [x] Resolving issues that are raised on the GitHub Issues Board(s)
- [x] Ensuring activity providers are aware of the OpenActive opportunity on an ongoing basis
