### PR TITLE
Add Bookteq.com to list of Data Catalogues

### DIFF
--- a/data-catalog-collection.jsonld
+++ b/data-catalog-collection.jsonld
@@ -6,7 +6,8 @@
    "hasPart": [
       "https://opendata.leisurecloud.live/api/datacatalog",
       "https://openactivedatacatalog.legendonlineservices.co.uk/api/DataCatalog",
-      "https://openactive.io/data-catalogs/singular.jsonld"
+      "https://openactive.io/data-catalogs/singular.jsonld",
+      "https://app.bookteq.com/api/openactive/catalogue"
    ],
    "datePublished": "2020-02-20T08:51:54+00:00",
    "publisher": {


### PR DESCRIPTION
This will be continually updated as we get more venues accepting the Openactive terms

## Publishing Checklist

I confirm the following:

- [x] My open data feeds conform to one of the permissable combinations specified in https://developer.openactive.io/publishing-data/data-feeds/types-of-feed
- [x] My open data feeds all pass the OpenActive Validator's model validation (https://validator.openactive.io/)
- [x] My open data feeds all pass the OpenActive Validator's RPDE feed validation (https://validator.openactive.io/rpde)
- [x] My open data feeds include activity list references as specified in https://developer.openactive.io/publishing-data/activity-list-references
- [x] My dataset site(s) each reference a GitHub Issues Board - We will work on this now

## Maintenance Checklist

Our organisation is committed to:

- [x] Resolving issues that are raised on the GitHub Issues Board(s)
- [x] Ensuring activity providers are aware of the OpenActive opportunity on an ongoing basis
