### PR TITLE
Remove data.tabletennis365.com

### DIFF
--- a/singular.jsonld
+++ b/singular.jsonld
@@ -27,7 +27,6 @@
     "https://playwaze.com/OpenData/OpenActive",
     "https://data.runtogether.co.uk/",
     "https://sportstarta.github.io/",
-    "http://data.tabletennis365.com/",
     "https://openactive.upshot.org.uk/",
     "https://opendata.exercise-anywhere.com/",
     "https://www.sportsuite.co.uk/odapikey/datasite/",


### PR DESCRIPTION
## Publishing Checklist

I confirm the following:

- [x] My open data feeds conform to one of the permissable combinations specified in https://developer.openactive.io/publishing-data/data-feeds/types-of-feed
- [x] My open data feeds all pass the OpenActive Validator's model validation (https://validator.openactive.io/)
- [x] My open data feeds all pass the OpenActive Validator's RPDE feed validation (https://validator.openactive.io/rpde)
- [x] My open data feeds include activity list references as specified in https://developer.openactive.io/publishing-data/activity-list-references
- [x] My dataset site(s) each reference a GitHub Issues Board

## Maintenance Checklist

Our organisation is committed to:

- [x] Ensuring activity providers are aware of the OpenActive initiative on an ongoing basis
- [x] Providing high quality opportunity data that meets user needs, as specified in [OpenActive's Data Quality reporting framework](https://developer.openactive.io/publishing-data/data-quality)
- [x] Resolving issues that are raised on the GitHub Issues Board(s)



