### PR TITLE
Remove failing datasets

### DIFF
--- a/singular-preview.jsonld
+++ b/singular-preview.jsonld
@@ -16,9 +16,6 @@
     "https://betterflow.coursepro.co.uk/odi/feed",
     "https://www.englandsquash.com/openactive",
     "http://www.schools-plus.co.uk/OpenActive.php",
-    "https://openactive.goodgym.org/",
-    "https://www.participant.co.uk/participant/openactive/",
-    "https://agb.sport80-clubs.com/openactive",
-    "http://data.pingengland.co.uk/"
+    "https://openactive.goodgym.org/"
   ]
 }


### PR DESCRIPTION
The following datasets have not been available for some time, and this PR removes them.

https://github.com/openactive/data-catalogs/issues/27#issuecomment-2621848731 includes these for further investigation.