### PR TITLE
Add Nettie — verified attendance data for women's sport in England

### DIFF
--- a/singular.jsonld
+++ b/singular.jsonld
@@ -34,6 +34,7 @@
     "https://openactive.played.co/openactive/",
     "https://api.premiertennis.co.uk/openactive",
     "https://partners.playfootball.net/OpenActive/",
-    "https://api.findmyfacility.com/v1/openactive"
+    "https://api.findmyfacility.com/v1/openactive",
+    "https://nettie.online/openactive"
   ]
 }


### PR DESCRIPTION
Nettie (nettie.online) is the first and only platform dedicated to verified attendance data for women's sport in England, through anonymous QR code check-ins at live fixtures. We cover all levels from elite to grassroots across football, rugby union, rugby league, netball, basketball, and handball.

The platform is currently onboarding founding clubs ahead of Season 1 in September 2026. The feed will grow significantly as club and fixture data is added over the coming weeks.

Fans can also check in directly via the Nettie website at nettie.online without needing a QR code at the venue.

## Publishing Checklist

I confirm the following:

- [x] My open data feeds conform to one of the permissable combinations specified in https://developer.openactive.io/publishing-data/data-feeds/types-of-feed
- [x] My open data feeds all pass the OpenActive Validator's model validation (https://validator.openactive.io/)
- [x] My open data feeds all pass the OpenActive Validator's RPDE feed validation (https://validator.openactive.io/rpde)
- [x] My open data feeds all pass the OpenActive Test Suite's deep validation (https://developer.openactive.io/publishing-data/data-feeds/testing-feeds#openactive-test-suite)
- [x] My open data feeds include activity list references as specified in https://developer.openactive.io/publishing-data/activity-list-references
- [x] My dataset site(s) each reference a GitHub Issues Board
- [x ] I have checked that the times in the feed `startDate` and `endDate` match the times on the website referenced by the `url`, and can confirm that there are no timezone issues

## Maintenance Checklist

Feed has been built and is live. Formal validator testing is in progress and will be completed before Season 1 launches in September 2026.

Our organisation is committed to:

- [x ] Ensuring activity providers are aware of the OpenActive initiative on an ongoing basis
- [x ] Providing high quality opportunity data that meets user needs, as specified in [OpenActive's Data Quality reporting framework](https://developer.openactive.io/publishing-data/data-quality)
- [x ] Resolving issues that are raised on the GitHub Issues Board(s)



